### PR TITLE
Restrict routes to and fro the collab page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import CollabRoute from "./routes/CollabRoute";
 import PrivateRoutes from "./routes/PrivateRoutes";
 import PublicRoutes from "./routes/PublicRoutes";
 import LoginPage from "./views/login/LoginPage";
@@ -8,8 +9,8 @@ import LandingPage from "./views/landing/LandingPage";
 import CollabPage from "./views/collab/CollabPage";
 import MatchingPage from "./views/MatchingPage";
 import CollabPage2 from "./views/collab/CollabPage2";
-import "./App.scss";
 import ForgotPasswordPage from "./views/forgotPassword/ForgotPasswordPage";
+import "./App.scss";
 
 function App() {
   return (
@@ -18,7 +19,9 @@ function App() {
         <Route element={<PrivateRoutes />}>
           <Route path="/match" element={<MatchingPage />} />
           <Route path="/collab" element={<CollabPage />} />
-          <Route path="/collab2" element={<CollabPage2 />} />
+          <Route element={<CollabRoute />}>
+            <Route path="/collab2" element={<CollabPage2 />} />
+          </Route>
         </Route>
         <Route element={<PublicRoutes />}>
           <Route path="/" element={<LandingPage />} />

--- a/frontend/src/components/ChatWindow/styles.scss
+++ b/frontend/src/components/ChatWindow/styles.scss
@@ -6,7 +6,6 @@
   min-height: 40vh;
   display: flex;
   flex-direction: column;
-  background-color: aqua;
 }
 
 #Chat-header-container {

--- a/frontend/src/components/MatchTimer.js
+++ b/frontend/src/components/MatchTimer.js
@@ -35,11 +35,11 @@ function MatchTimer(props) {
   });
 
   socket.on("waiting match", (data) => {
-    console.log(data);
+    console.log("waiting match", data);
   });
 
   socket.on("match cancelled", (data) => {
-    console.log(data);
+    console.log("match cancelled", data);
   });
 
   useEffect(() => {

--- a/frontend/src/components/NavBar/index.js
+++ b/frontend/src/components/NavBar/index.js
@@ -10,9 +10,11 @@ import { useNavigate } from "react-router-dom";
 import { logoutUser } from "../../stores/user";
 import { getUsername, hasToken } from "../../utils/localStorageUtils";
 import logo from "../../assets/logo-white.png";
+
+import PropTypes from "prop-types";
 import "./styles.scss";
 
-function NavBar() {
+function NavBar({ logoHref }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [showChangePasswordModal, setShowChangePasswordModal] = useState(false);
@@ -58,7 +60,7 @@ function NavBar() {
     <>
       <Navbar bg="light" fixed="top">
         <Container fluid>
-          <Navbar.Brand href="/match" className="Navbar-peerprep text-white">
+          <Navbar.Brand href={logoHref || "/match"} className="Navbar-peerprep text-white">
             <img alt="" src={logo} width="30" height="30" className="d-inline-block align-top" />{" "}
             PeerPrep
           </Navbar.Brand>
@@ -110,5 +112,9 @@ function NavBar() {
     </>
   );
 }
+
+NavBar.propTypes = {
+  logoHref: PropTypes.string,
+};
 
 export default NavBar;

--- a/frontend/src/routes/CollabRoute.js
+++ b/frontend/src/routes/CollabRoute.js
@@ -1,0 +1,10 @@
+import { useSelector } from "react-redux";
+import { Outlet, Navigate } from "react-router-dom";
+import { matchSelector } from "../stores/match/match.slice";
+
+const CollabRoute = () => {
+  const { matchId } = useSelector(matchSelector);
+  return matchId !== null && matchId !== "" ? <Outlet /> : <Navigate to="/match" />;
+};
+
+export default CollabRoute;

--- a/frontend/src/views/MatchingPage.js
+++ b/frontend/src/views/MatchingPage.js
@@ -6,12 +6,11 @@ import configs from "../utils/configs";
 const config = configs[process.env.NODE_ENV];
 
 function MatchingPage() {
-  console.log("MatchPage");
   const socket = io.connect(config.MATCH_SVC_BASE_URL, {
     path: "/matching-api",
   });
   socket.on("connect_error", (data) => {
-    console.log(data);
+    console.log("Matching socket connection error:", data);
     socket.disconnect();
   });
 

--- a/frontend/src/views/collab/CollabPage2.js
+++ b/frontend/src/views/collab/CollabPage2.js
@@ -14,7 +14,7 @@ function CollabPage2() {
   return (
     <>
       <div className="Collab2-container">
-        <NavBar />
+        <NavBar logoHref="#" />
         <div className="Collab2-content-div">
           <div className="Collab2-left-div">
             <QuestionCard containerId="Collab2-qn-card-container" />


### PR DESCRIPTION
Closes #55 

Reroute unmatched users from `/collab2` back to `/match`.
Prevent matched users from routing back to `/match` when clicking the logo in the `NavBar`.