### PR TITLE
Add shell script for mac in root dir to start all services in local dev

### DIFF
--- a/run-services-mac.sh
+++ b/run-services-mac.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+osascript -e 'tell application "Terminal"
+  activate
+  do script "echo Setting up services..." in front window
+  
+  my makeTab()
+  do script "cd ./frontend/" in front window
+  do script "npm ci && npm run start-mac" in front window
+  
+  my makeTab()
+  do script "cd ../user-service/" in front window
+  do script "npm ci && npm run dev" in front window
+
+  my makeTab()
+  do script "cd ../matching-service/" in front window
+  do script "npm ci && npm run dev" in front window
+
+  my makeTab()
+  do script "cd ../question-service/" in front window
+  do script "npm ci && npm run dev" in front window
+
+  my makeTab()
+  do script "cd ../communication-service/" in front window
+  do script "npm ci && npm run dev" in front window
+
+end tell
+
+on makeTab()
+  tell application "System Events" to keystroke "t" using {command down}
+  delay 0.2
+end makeTab'


### PR DESCRIPTION
Starts the following services in different terminal tabs:
 - Frontend
 - User service
 - Matching service
 - Question service
 - Communication service